### PR TITLE
Fix terminal search bar on mac

### DIFF
--- a/src/main/java/p455w0rd/ae2wtlib/api/client/gui/GuiWT.java
+++ b/src/main/java/p455w0rd/ae2wtlib/api/client/gui/GuiWT.java
@@ -534,12 +534,7 @@ public abstract class GuiWT extends GuiContainer {
 	}
 
 	public static boolean isTabKeyDown() {
-		if (Minecraft.IS_RUNNING_ON_MAC) {
-			return Keyboard.isKeyDown(48);
-		}
-		else {
-			return Keyboard.isKeyDown(15);
-		}
+		return Keyboard.isKeyDown(15);
 	}
 
 	public static class Size1Slot extends SlotItemHandler {


### PR DESCRIPTION
I play minecraft on Mac (macOS Mojave 10.14.3), encoutering following problem:
When I type "b" in search bar, text will get wiped out.
Video: https://youtu.be/fqwz4RmpSsQ

The problem is cause by [WirelessCraftingTerminal/.../GuiWCT#870](https://github.com/p455w0rd/WirelessCraftingTerminal/blob/master/src/main/java/p455w0rd/wct/client/gui/GuiWCT.java#L870), because when "b" pressed, it's consider as Tab key here: [api/base/GuiWT.java#532](https://github.com/p455w0rd/AE2WirelessTerminalLibrary/blob/master/src/main/java/p455w0rd/ae2wtlib/api/base/GuiWT.java#L532)

There must be some reason for handing tab differently on Mac, but I cannot find the related issue. I only found the [commit](https://github.com/p455w0rd/WirelessCraftingTerminal/commit/5237ac8f1776bd709828d025db0fd9bdefd0f84b#diff-da66f6bb259099ef4cf2d07226f41ecbR804) those lines was added. 